### PR TITLE
Migrate from wrapper-validation@v3 to setup-gradle@v5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,9 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+
       - name: Run linter
         run: ./gradlew lint
 
@@ -68,6 +71,9 @@ jobs:
         with:
           java-version: '17'
           distribution: 'adopt'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Kotlin linter
         run: ./gradlew ktlintCheck


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI build workflow to use a refreshed Gradle setup across build, lint, and formatting jobs; removed the previous Gradle cache step and simplified build steps.

**Note:** This release contains no user-facing changes; updates were limited to internal CI/build configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->