### PR TITLE
Allow decoding P2WPKH addresses from scriptpubkeys

### DIFF
--- a/arkade/src/commonMain/kotlin/com/arkade/core/bitcoin/Address.kt
+++ b/arkade/src/commonMain/kotlin/com/arkade/core/bitcoin/Address.kt
@@ -94,18 +94,18 @@ data class Address(
             network: Network,
         ): Address {
             val scriptPubKeySize = scriptPubKey.size
-            require(scriptPubKeySize == 34) {
+            require(scriptPubKeySize == 34 || scriptPubKeySize == 22) {
                 "Invalid scriptPubKey length, expected 34 bytes but got $scriptPubKeySize"
             }
             val witnessProgramPushByte = scriptPubKey[1]
-            require(witnessProgramPushByte == 0x20.toByte()) {
+            require(witnessProgramPushByte == 0x20.toByte() || witnessProgramPushByte == 0x14.toByte()) {
                 "Invalid witness program push length, expected 0x20 but got $witnessProgramPushByte"
             }
             val witnessVersion = WitnessVersion.fromByte(scriptPubKey[0])
             require(witnessVersion == WitnessVersion.SEGWIT || witnessVersion == WitnessVersion.TAPROOT) {
                 "Unsupported witness version"
             }
-            val witnessProgram = scriptPubKey.copyOfRange(2, 34)
+            val witnessProgram = scriptPubKey.copyOfRange(2, scriptPubKeySize)
             val hrp = Hrp.fromNetwork(network)
             return Address(
                 hrp,

--- a/arkade/src/commonMain/kotlin/com/arkade/core/bitcoin/Address.kt
+++ b/arkade/src/commonMain/kotlin/com/arkade/core/bitcoin/Address.kt
@@ -95,11 +95,14 @@ data class Address(
         ): Address {
             val scriptPubKeySize = scriptPubKey.size
             require(scriptPubKeySize == 34 || scriptPubKeySize == 22) {
-                "Invalid scriptPubKey length, expected 34 bytes but got $scriptPubKeySize"
+                "Invalid scriptPubKey length, expected 22 or 34 bytes but got $scriptPubKeySize"
             }
             val witnessProgramPushByte = scriptPubKey[1]
+            require(witnessProgramPushByte.toInt() == scriptPubKeySize - 2) {
+                "Invalid witness program push length, expected $witnessProgramPushByte but got ${scriptPubKeySize - 2}"
+            }
             require(witnessProgramPushByte == 0x20.toByte() || witnessProgramPushByte == 0x14.toByte()) {
-                "Invalid witness program push length, expected 0x20 but got $witnessProgramPushByte"
+                "Invalid witness program push length, expected 0x20 or 0x14 but got $witnessProgramPushByte"
             }
             val witnessVersion = WitnessVersion.fromByte(scriptPubKey[0])
             require(witnessVersion == WitnessVersion.SEGWIT || witnessVersion == WitnessVersion.TAPROOT) {

--- a/arkade/src/commonTest/kotlin/com/arkade/core/OnChainAddressTest.kt
+++ b/arkade/src/commonTest/kotlin/com/arkade/core/OnChainAddressTest.kt
@@ -132,7 +132,7 @@ class OnChainTaprootAddressTest {
     @Test
     fun regtest_fail_creating_address_on_malformed_script_pubkey() {
         assertFailsWith<IllegalArgumentException> {
-            Address.fromScriptPubKey(malformedScriptPubKey, Network.TESTNET)
+            Address.fromScriptPubKey(malformedScriptPubKey, Network.REGTEST)
         }
     }
 

--- a/arkade/src/commonTest/kotlin/com/arkade/core/OnChainAddressTest.kt
+++ b/arkade/src/commonTest/kotlin/com/arkade/core/OnChainAddressTest.kt
@@ -12,22 +12,24 @@ class OnChainTaprootAddressTest {
     val mainnetAddress = "bc1pjhe7sjma3rnkdfelsrj5l6g58z9ysclkrjxgy0duxcp9k6r9atjst0yf78"
     val testnetAddress = "tb1pjhe7sjma3rnkdfelsrj5l6g58z9ysclkrjxgy0duxcp9k6r9atjsu8jxyg"
     val regtestAddress = "bcrt1pjhe7sjma3rnkdfelsrj5l6g58z9ysclkrjxgy0duxcp9k6r9atjs37cq3j"
+    val witnessProgram = "95f3e84b7d88e766a73f80e54fe914388a4863f61c8c823dbc36025b6865eae5"
+    val scriptPubKey = "512095f3e84b7d88e766a73f80e54fe914388a4863f61c8c823dbc36025b6865eae5".hexToByteArray()
+    val malformedScriptPubKey = "511495f3e84b7d88e766a73f80e54fe914388a4863f61c8c823dbc36025b6865eae5".hexToByteArray()
 
     @Test
     fun mainnet_round_trip() {
         val network = Network.MAINNET
-        val scriptPubKey = "512095f3e84b7d88e766a73f80e54fe914388a4863f61c8c823dbc36025b6865eae5".hexToByteArray()
 
         val decoded = Address.decode(mainnetAddress)
 
         assertEquals("bc", decoded.hrp.prefix)
         assertEquals(WitnessVersion.TAPROOT, decoded.witnessVersion)
-        assertEquals("95f3e84b7d88e766a73f80e54fe914388a4863f61c8c823dbc36025b6865eae5", decoded.witnessProgram.toHexString())
+        assertEquals(witnessProgram, decoded.witnessProgram.toHexString())
 
         val fromScriptPubKey = Address.fromScriptPubKey(scriptPubKey, network)
         assertEquals("bc", fromScriptPubKey.hrp.prefix)
         assertEquals(WitnessVersion.TAPROOT, fromScriptPubKey.witnessVersion)
-        assertEquals("95f3e84b7d88e766a73f80e54fe914388a4863f61c8c823dbc36025b6865eae5", fromScriptPubKey.witnessProgram.toHexString())
+        assertEquals(witnessProgram, fromScriptPubKey.witnessProgram.toHexString())
 
         val encoded = decoded.encode()
         assertEquals(mainnetAddress, encoded)
@@ -44,6 +46,13 @@ class OnChainTaprootAddressTest {
                 WitnessVersion.TAPROOT,
                 decoded.witnessProgram.copyOfRange(3, 16),
             )
+        }
+    }
+
+    @Test
+    fun mainnet_fail_creating_address_on_malformed_script_pubkey() {
+        assertFailsWith<IllegalArgumentException> {
+            Address.fromScriptPubKey(malformedScriptPubKey, Network.MAINNET)
         }
     }
 
@@ -82,6 +91,13 @@ class OnChainTaprootAddressTest {
     }
 
     @Test
+    fun testnet_fail_creating_address_on_malformed_script_pubkey() {
+        assertFailsWith<IllegalArgumentException> {
+            Address.fromScriptPubKey(malformedScriptPubKey, Network.TESTNET)
+        }
+    }
+
+    @Test
     fun regtest_round_trip() {
         val network = Network.REGTEST
         val scriptPubKey = "512095f3e84b7d88e766a73f80e54fe914388a4863f61c8c823dbc36025b6865eae5".hexToByteArray()
@@ -112,6 +128,13 @@ class OnChainTaprootAddressTest {
                 WitnessVersion.TAPROOT,
                 decoded.witnessProgram.copyOfRange(3, 16),
             )
+        }
+    }
+
+    @Test
+    fun regtest_fail_creating_address_on_malformed_script_pubkey() {
+        assertFailsWith<IllegalArgumentException> {
+            Address.fromScriptPubKey(malformedScriptPubKey, Network.TESTNET)
         }
     }
 
@@ -129,6 +152,7 @@ class OnChainSegwitAddressTest {
     val regtestAddress = "bcrt1q6jktr35gzw37e7gh96fkm5w8qp256f8qlm7cpj"
     val witnessProgram = "d4acb1c68813a3ecf9172e936dd1c700554d24e0"
     val scriptPubKey = "0014d4acb1c68813a3ecf9172e936dd1c700554d24e0".hexToByteArray()
+    val malformedScriptPubKey = "0020d4acb1c68813a3ecf9172e936dd1c700554d24e0".hexToByteArray()
 
     @Test
     fun mainnet_round_trip() {
@@ -160,6 +184,13 @@ class OnChainSegwitAddressTest {
                 WitnessVersion.SEGWIT,
                 decoded.witnessProgram.copyOfRange(3, 16),
             )
+        }
+    }
+
+    @Test
+    fun mainnet_fail_creating_address_on_malformed_script_pubkey() {
+        assertFailsWith<IllegalArgumentException> {
+            Address.fromScriptPubKey(malformedScriptPubKey, Network.MAINNET)
         }
     }
 
@@ -197,6 +228,13 @@ class OnChainSegwitAddressTest {
     }
 
     @Test
+    fun testnet_fail_creating_address_on_malformed_script_pubkey() {
+        assertFailsWith<IllegalArgumentException> {
+            Address.fromScriptPubKey(malformedScriptPubKey, Network.TESTNET)
+        }
+    }
+
+    @Test
     fun regtest_round_trip() {
         val network = Network.REGTEST
 
@@ -226,6 +264,13 @@ class OnChainSegwitAddressTest {
                 WitnessVersion.SEGWIT,
                 decoded.witnessProgram.copyOfRange(3, 16),
             )
+        }
+    }
+
+    @Test
+    fun regtest_fail_creating_address_on_malformed_script_pubkey() {
+        assertFailsWith<IllegalArgumentException> {
+            Address.fromScriptPubKey(malformedScriptPubKey, Network.REGTEST)
         }
     }
 

--- a/arkade/src/commonTest/kotlin/com/arkade/core/OnChainAddressTest.kt
+++ b/arkade/src/commonTest/kotlin/com/arkade/core/OnChainAddressTest.kt
@@ -8,7 +8,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
-class OnChainAddressTest {
+class OnChainTaprootAddressTest {
     val mainnetAddress = "bc1pjhe7sjma3rnkdfelsrj5l6g58z9ysclkrjxgy0duxcp9k6r9atjst0yf78"
     val testnetAddress = "tb1pjhe7sjma3rnkdfelsrj5l6g58z9ysclkrjxgy0duxcp9k6r9atjsu8jxyg"
     val regtestAddress = "bcrt1pjhe7sjma3rnkdfelsrj5l6g58z9ysclkrjxgy0duxcp9k6r9atjs37cq3j"
@@ -110,6 +110,120 @@ class OnChainAddressTest {
             Address(
                 Hrp.REGTEST,
                 WitnessVersion.TAPROOT,
+                decoded.witnessProgram.copyOfRange(3, 16),
+            )
+        }
+    }
+
+    @Test
+    fun fail_on_unsupported_witness_version() {
+        assertFailsWith<IllegalArgumentException> {
+            WitnessVersion.fromInt(3)
+        }
+    }
+}
+
+class OnChainSegwitAddressTest {
+    val mainnetAddress = "bc1q6jktr35gzw37e7gh96fkm5w8qp256f8qh5uxdg"
+    val testnetAddress = "tb1q6jktr35gzw37e7gh96fkm5w8qp256f8qaj84km"
+    val regtestAddress = "bcrt1q6jktr35gzw37e7gh96fkm5w8qp256f8qlm7cpj"
+    val witnessProgram = "d4acb1c68813a3ecf9172e936dd1c700554d24e0"
+    val scriptPubKey = "0014d4acb1c68813a3ecf9172e936dd1c700554d24e0".hexToByteArray()
+
+    @Test
+    fun mainnet_round_trip() {
+        val network = Network.MAINNET
+
+        val decoded = Address.decode(mainnetAddress)
+
+        assertEquals("bc", decoded.hrp.prefix)
+        assertEquals(WitnessVersion.SEGWIT, decoded.witnessVersion)
+        assertEquals(witnessProgram, decoded.witnessProgram.toHexString())
+
+        val fromScriptPubKey = Address.fromScriptPubKey(scriptPubKey, network)
+        assertEquals("bc", fromScriptPubKey.hrp.prefix)
+        assertEquals(WitnessVersion.SEGWIT, fromScriptPubKey.witnessVersion)
+        assertEquals(witnessProgram, fromScriptPubKey.witnessProgram.toHexString())
+
+        val encoded = decoded.encode()
+        assertEquals(mainnetAddress, encoded)
+
+        assertEquals(scriptPubKey.toHexString(), decoded.toScriptPubKey().toHexString())
+    }
+
+    @Test
+    fun mainnet_fail_creating_address_on_invalid_witness_program_length() {
+        val decoded = Address.decode(mainnetAddress)
+        assertFailsWith<IllegalArgumentException> {
+            Address(
+                Hrp.MAINNET,
+                WitnessVersion.SEGWIT,
+                decoded.witnessProgram.copyOfRange(3, 16),
+            )
+        }
+    }
+
+    @Test
+    fun testnet_round_trip() {
+        val network = Network.TESTNET
+
+        val decoded = Address.decode(testnetAddress)
+
+        assertEquals("tb", decoded.hrp.prefix)
+        assertEquals(WitnessVersion.SEGWIT, decoded.witnessVersion)
+        assertEquals(witnessProgram, decoded.witnessProgram.toHexString())
+
+        val fromScriptPubKey = Address.fromScriptPubKey(scriptPubKey, network)
+        assertEquals("tb", fromScriptPubKey.hrp.prefix)
+        assertEquals(WitnessVersion.SEGWIT, fromScriptPubKey.witnessVersion)
+        assertEquals(witnessProgram, fromScriptPubKey.witnessProgram.toHexString())
+
+        val encoded = decoded.encode()
+        assertEquals(testnetAddress, encoded)
+
+        assertEquals(scriptPubKey.toHexString(), decoded.toScriptPubKey().toHexString())
+    }
+
+    @Test
+    fun testnet_fail_creating_address_on_invalid_witness_program_length() {
+        val decoded = Address.decode(testnetAddress)
+        assertFailsWith<IllegalArgumentException> {
+            Address(
+                Hrp.TESTNETS,
+                WitnessVersion.SEGWIT,
+                decoded.witnessProgram.copyOfRange(3, 16),
+            )
+        }
+    }
+
+    @Test
+    fun regtest_round_trip() {
+        val network = Network.REGTEST
+
+        val decoded = Address.decode(regtestAddress)
+
+        assertEquals("bcrt", decoded.hrp.prefix)
+        assertEquals(WitnessVersion.SEGWIT, decoded.witnessVersion)
+        assertEquals(witnessProgram, decoded.witnessProgram.toHexString())
+
+        val fromScriptPubKey = Address.fromScriptPubKey(scriptPubKey, network)
+        assertEquals("bcrt", fromScriptPubKey.hrp.prefix)
+        assertEquals(WitnessVersion.SEGWIT, fromScriptPubKey.witnessVersion)
+        assertEquals(witnessProgram, fromScriptPubKey.witnessProgram.toHexString())
+
+        val encoded = decoded.encode()
+        assertEquals(regtestAddress, encoded)
+
+        assertEquals(scriptPubKey.toHexString(), decoded.toScriptPubKey().toHexString())
+    }
+
+    @Test
+    fun regtest_fail_creating_address_on_invalid_witness_program_length() {
+        val decoded = Address.decode(regtestAddress)
+        assertFailsWith<IllegalArgumentException> {
+            Address(
+                Hrp.REGTEST,
+                WitnessVersion.SEGWIT,
                 decoded.witnessProgram.copyOfRange(3, 16),
             )
         }

--- a/arkade/src/commonTest/kotlin/com/arkade/core/OnChainAddressTest.kt
+++ b/arkade/src/commonTest/kotlin/com/arkade/core/OnChainAddressTest.kt
@@ -59,18 +59,17 @@ class OnChainTaprootAddressTest {
     @Test
     fun testnet_round_trip() {
         val network = Network.TESTNET
-        val scriptPubKey = "512095f3e84b7d88e766a73f80e54fe914388a4863f61c8c823dbc36025b6865eae5".hexToByteArray()
 
         val decoded = Address.decode(testnetAddress)
 
         assertEquals("tb", decoded.hrp.prefix)
         assertEquals(WitnessVersion.TAPROOT, decoded.witnessVersion)
-        assertEquals("95f3e84b7d88e766a73f80e54fe914388a4863f61c8c823dbc36025b6865eae5", decoded.witnessProgram.toHexString())
+        assertEquals(witnessProgram, decoded.witnessProgram.toHexString())
 
         val fromScriptPubKey = Address.fromScriptPubKey(scriptPubKey, network)
         assertEquals("tb", fromScriptPubKey.hrp.prefix)
         assertEquals(WitnessVersion.TAPROOT, fromScriptPubKey.witnessVersion)
-        assertEquals("95f3e84b7d88e766a73f80e54fe914388a4863f61c8c823dbc36025b6865eae5", fromScriptPubKey.witnessProgram.toHexString())
+        assertEquals(witnessProgram, fromScriptPubKey.witnessProgram.toHexString())
 
         val encoded = decoded.encode()
         assertEquals(testnetAddress, encoded)
@@ -100,18 +99,17 @@ class OnChainTaprootAddressTest {
     @Test
     fun regtest_round_trip() {
         val network = Network.REGTEST
-        val scriptPubKey = "512095f3e84b7d88e766a73f80e54fe914388a4863f61c8c823dbc36025b6865eae5".hexToByteArray()
 
         val decoded = Address.decode(regtestAddress)
 
         assertEquals("bcrt", decoded.hrp.prefix)
         assertEquals(WitnessVersion.TAPROOT, decoded.witnessVersion)
-        assertEquals("95f3e84b7d88e766a73f80e54fe914388a4863f61c8c823dbc36025b6865eae5", decoded.witnessProgram.toHexString())
+        assertEquals(witnessProgram, decoded.witnessProgram.toHexString())
 
         val fromScriptPubKey = Address.fromScriptPubKey(scriptPubKey, network)
         assertEquals("bcrt", fromScriptPubKey.hrp.prefix)
         assertEquals(WitnessVersion.TAPROOT, fromScriptPubKey.witnessVersion)
-        assertEquals("95f3e84b7d88e766a73f80e54fe914388a4863f61c8c823dbc36025b6865eae5", fromScriptPubKey.witnessProgram.toHexString())
+        assertEquals(witnessProgram, fromScriptPubKey.witnessProgram.toHexString())
 
         val encoded = decoded.encode()
         assertEquals(regtestAddress, encoded)


### PR DESCRIPTION
Resolves #25 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved on-chain address parsing to accept additional SegWit scriptPubKey lengths and both 20- and 32-byte witness programs; updated validation and error messages.

* **Tests**
  * Expanded coverage: separated Taproot and SegWit tests, added round-trip encode/decode and scriptPubKey checks, and added negative tests for malformed scripts, invalid witness lengths and unsupported witness versions across mainnet/testnet/regtest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->