### PR TITLE
refactor: Create X-Only public keys cleanly

### DIFF
--- a/arkade/src/commonMain/kotlin/com/arkade/core/BoardingOutput.kt
+++ b/arkade/src/commonMain/kotlin/com/arkade/core/BoardingOutput.kt
@@ -7,7 +7,6 @@ import com.arkade.core.bitcoin.Utxo
 import com.arkade.core.taproot.Parity
 import com.arkade.core.taproot.TaprootSpendingInfo
 import fr.acinq.bitcoin.ByteVector
-import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.OutPoint
 import fr.acinq.bitcoin.Script
 import fr.acinq.bitcoin.ScriptTree
@@ -145,7 +144,7 @@ data class BoardingOutput(
                 )
             val merkleRoot = merkleTree.hash()
 
-            val internalKey = XonlyPublicKey(ByteVector32.fromValidHex(UNSPENDABLE_PUBKEY))
+            val internalKey = UNSPENDABLE_PUBKEY.toXOnlyPubKey()
             val (outputKey, isOdd) = internalKey.outputKey(merkleTree)
             val spendingInfo =
                 TaprootSpendingInfo(

--- a/arkade/src/commonMain/kotlin/com/arkade/core/Utils.kt
+++ b/arkade/src/commonMain/kotlin/com/arkade/core/Utils.kt
@@ -2,6 +2,9 @@ package com.arkade.core
 
 import com.ionspin.kotlin.bignum.decimal.BigDecimal
 import com.ionspin.kotlin.bignum.decimal.toBigDecimal
+import fr.acinq.bitcoin.ByteVector32
+import fr.acinq.bitcoin.PublicKey
+import fr.acinq.bitcoin.XonlyPublicKey
 
 /**
  * The unspendable x-only public key, nobody knows the private key. Any funds locked to this public key cannot be spent,
@@ -24,4 +27,21 @@ fun <T> Iterable<T>.sumOf(selector: (T) -> BigDecimal): BigDecimal {
         sum += selector(element)
     }
     return sum
+}
+
+/**
+ * Converts a hex string to an [XonlyPublicKey] public key
+ * The hex string can be an uncompressed, compressed or x-only public key
+ * @return the [XonlyPublicKey] public key
+ */
+fun String.toXOnlyPubKey(): XonlyPublicKey {
+    val bytes = hexToByteArray()
+    val bytesSize = bytes.size
+    if (bytesSize == 32) {
+        return XonlyPublicKey(ByteVector32(bytes))
+    }
+    if (bytesSize == 33 || bytesSize == 65) {
+        return PublicKey.parse(bytes).xOnly()
+    }
+    throw IllegalArgumentException("Invalid public key: $this")
 }

--- a/arkade/src/commonMain/kotlin/com/arkade/core/Vtxo.kt
+++ b/arkade/src/commonMain/kotlin/com/arkade/core/Vtxo.kt
@@ -7,7 +7,6 @@ import com.arkade.core.taproot.Parity
 import com.arkade.core.taproot.TaprootSpendingInfo
 import com.ionspin.kotlin.bignum.decimal.BigDecimal
 import fr.acinq.bitcoin.ByteVector
-import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.OutPoint
 import fr.acinq.bitcoin.Script
 import fr.acinq.bitcoin.ScriptTree
@@ -170,7 +169,7 @@ data class Vtxo(
         ): Vtxo {
             require(exitDelay in 0..0xFFFFL) { "Exit delay time is out of range" }
             require(tapScripts.size == 2) { "Expects exactly 2 tap scripts: forfeit and exit" }
-            val unSpendablePubKey = XonlyPublicKey(ByteVector32.fromValidHex(UNSPENDABLE_PUBKEY))
+            val unSpendablePubKey = UNSPENDABLE_PUBKEY.toXOnlyPubKey()
 
             val (forfeitScript, exitScript) = tapScripts
             val forfeitLeaf = ScriptTree.Leaf(ByteVector(forfeitScript), 0)

--- a/arkade/src/commonTest/kotlin/com/arkade/core/BoardingOutputTest.kt
+++ b/arkade/src/commonTest/kotlin/com/arkade/core/BoardingOutputTest.kt
@@ -4,21 +4,19 @@ import com.arkade.core.bitcoin.Address
 import com.arkade.core.bitcoin.Network
 import com.arkade.core.taproot.Parity
 import fr.acinq.bitcoin.ByteVector
-import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.Crypto
-import fr.acinq.bitcoin.PublicKey
 import fr.acinq.bitcoin.Script
 import fr.acinq.bitcoin.ScriptTree
-import fr.acinq.bitcoin.XonlyPublicKey
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class BoardingOutputTest {
+    val serverPubKey = "03a19310a999207dbd9a03d20f649e37c7a578a07d75e6fa19aa3f33fc6b15622c".toXOnlyPubKey()
+    val ownerPubKey = "0315fbe13a8cf7e4d0c81b0caf4040f37666933d97080abb04f908964bb14588a8".toXOnlyPubKey()
+    val unSpendablePubKey = UNSPENDABLE_PUBKEY.toXOnlyPubKey()
+
     @Test
     fun mainnet_should_succeed_on_creating_boarding_output() {
-        val serverPubKey = PublicKey.fromHex("03a19310a999207dbd9a03d20f649e37c7a578a07d75e6fa19aa3f33fc6b15622c").xOnly()
-        val ownerPubKey = PublicKey.fromHex("0315fbe13a8cf7e4d0c81b0caf4040f37666933d97080abb04f908964bb14588a8").xOnly()
-
         val boardingOutput =
             BoardingOutput.create(
                 serverPubKey,
@@ -37,7 +35,6 @@ class BoardingOutputTest {
         val scriptTree = ScriptTree.Branch(forfeitLeaf, exitLeaf)
         val merkleRoot = scriptTree.hash()
 
-        val unSpendablePubKey = XonlyPublicKey(ByteVector32.fromValidHex(UNSPENDABLE_PUBKEY))
         val scriptPubKey =
             with(Script) {
                 write(pay2tr(unSpendablePubKey, Crypto.TaprootTweak.ScriptPathTweak(merkleRoot)))
@@ -77,9 +74,6 @@ class BoardingOutputTest {
 
     @Test
     fun testnet_should_succeed_on_creating_boarding_output() {
-        val serverPubKey = PublicKey.fromHex("03a19310a999207dbd9a03d20f649e37c7a578a07d75e6fa19aa3f33fc6b15622c").xOnly()
-        val ownerPubKey = PublicKey.fromHex("0315fbe13a8cf7e4d0c81b0caf4040f37666933d97080abb04f908964bb14588a8").xOnly()
-
         val boardingOutput =
             BoardingOutput.create(
                 serverPubKey,
@@ -98,7 +92,6 @@ class BoardingOutputTest {
         val scriptTree = ScriptTree.Branch(forfeitLeaf, exitLeaf)
         val merkleRoot = scriptTree.hash()
 
-        val unSpendablePubKey = XonlyPublicKey(ByteVector32.fromValidHex(UNSPENDABLE_PUBKEY))
         val scriptPubKey =
             with(Script) {
                 write(pay2tr(unSpendablePubKey, Crypto.TaprootTweak.ScriptPathTweak(merkleRoot)))
@@ -138,9 +131,6 @@ class BoardingOutputTest {
 
     @Test
     fun regtest_should_succeed_on_creating_boarding_output() {
-        val serverPubKey = PublicKey.fromHex("03a19310a999207dbd9a03d20f649e37c7a578a07d75e6fa19aa3f33fc6b15622c").xOnly()
-        val ownerPubKey = PublicKey.fromHex("0315fbe13a8cf7e4d0c81b0caf4040f37666933d97080abb04f908964bb14588a8").xOnly()
-
         val boardingOutput =
             BoardingOutput.create(
                 serverPubKey,
@@ -159,7 +149,6 @@ class BoardingOutputTest {
         val scriptTree = ScriptTree.Branch(forfeitLeaf, exitLeaf)
         val merkleRoot = scriptTree.hash()
 
-        val unSpendablePubKey = XonlyPublicKey(ByteVector32.fromValidHex(UNSPENDABLE_PUBKEY))
         val scriptPubKey =
             with(Script) {
                 write(pay2tr(unSpendablePubKey, Crypto.TaprootTweak.ScriptPathTweak(merkleRoot)))

--- a/arkade/src/commonTest/kotlin/com/arkade/core/VtxoTest.kt
+++ b/arkade/src/commonTest/kotlin/com/arkade/core/VtxoTest.kt
@@ -4,19 +4,17 @@ import com.arkade.core.bitcoin.Address
 import com.arkade.core.bitcoin.Network
 import com.arkade.core.taproot.Parity
 import fr.acinq.bitcoin.ByteVector
-import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.Crypto
-import fr.acinq.bitcoin.PublicKey
 import fr.acinq.bitcoin.Script
 import fr.acinq.bitcoin.ScriptTree
-import fr.acinq.bitcoin.XonlyPublicKey
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class VtxoTest {
-    val serverPubKey = PublicKey.fromHex("03a19310a999207dbd9a03d20f649e37c7a578a07d75e6fa19aa3f33fc6b15622c").xOnly()
-    val ownerPubKey = PublicKey.fromHex("0315fbe13a8cf7e4d0c81b0caf4040f37666933d97080abb04f908964bb14588a8").xOnly()
+    val serverPubKey = "03a19310a999207dbd9a03d20f649e37c7a578a07d75e6fa19aa3f33fc6b15622c".toXOnlyPubKey()
+    val ownerPubKey = "0315fbe13a8cf7e4d0c81b0caf4040f37666933d97080abb04f908964bb14588a8".toXOnlyPubKey()
+    val unSpendablePubKey = UNSPENDABLE_PUBKEY.toXOnlyPubKey()
 
     @Test
     fun mainnet_should_succeed_on_building_vtxo() {
@@ -37,7 +35,6 @@ class VtxoTest {
         val scriptTree = ScriptTree.Branch(forfeitLeaf, exitLeaf)
         val merkleRoot = scriptTree.hash()
 
-        val unSpendablePubKey = XonlyPublicKey(ByteVector32.fromValidHex(UNSPENDABLE_PUBKEY))
         val scriptPubKey =
             with(Script) {
                 write(pay2tr(unSpendablePubKey, Crypto.TaprootTweak.ScriptPathTweak(merkleRoot)))
@@ -96,7 +93,6 @@ class VtxoTest {
         val scriptTree = ScriptTree.Branch(forfeitLeaf, exitLeaf)
         val merkleRoot = scriptTree.hash()
 
-        val unSpendablePubKey = XonlyPublicKey(ByteVector32.fromValidHex(UNSPENDABLE_PUBKEY))
         val scriptPubKey =
             with(Script) {
                 write(pay2tr(unSpendablePubKey, Crypto.TaprootTweak.ScriptPathTweak(merkleRoot)))
@@ -147,7 +143,6 @@ class VtxoTest {
         val scriptTree = ScriptTree.Branch(forfeitLeaf, exitLeaf)
         val merkleRoot = scriptTree.hash()
 
-        val unSpendablePubKey = XonlyPublicKey(ByteVector32.fromValidHex(UNSPENDABLE_PUBKEY))
         val scriptPubKey =
             with(Script) {
                 write(pay2tr(unSpendablePubKey, Crypto.TaprootTweak.ScriptPathTweak(merkleRoot)))

--- a/arkade/src/commonTest/kotlin/com/arkade/core/XOnlyPublicKeyTest.kt
+++ b/arkade/src/commonTest/kotlin/com/arkade/core/XOnlyPublicKeyTest.kt
@@ -1,0 +1,33 @@
+package com.arkade.core
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class XOnlyPublicKeyTest {
+    val unCompressedNums =
+        "0450929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace8" +
+            "03ac031d3c6863973926e049e637cb1b5f40a36dac28af1766968c30c2313f3a38904"
+    val malformedUnCompressedNums =
+        "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace8" +
+            "03ac031d3c6863973926e049e637cb1b5f40a36dac28af1766968c30c2313f3a38904"
+    val compressedNums = "0350929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
+    val xOnlyNums = "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
+
+    @Test
+    fun should_decode_pub_keys_correctly() {
+        val decodedUnCompressedNums = unCompressedNums.toXOnlyPubKey()
+        assertEquals(UNSPENDABLE_PUBKEY, decodedUnCompressedNums.value.toHex())
+        val decodedCompressedNums = compressedNums.toXOnlyPubKey()
+        assertEquals(UNSPENDABLE_PUBKEY, decodedCompressedNums.value.toHex())
+        val decodedXOnlyNums = xOnlyNums.toXOnlyPubKey()
+        assertEquals(UNSPENDABLE_PUBKEY, decodedXOnlyNums.value.toHex())
+    }
+
+    @Test
+    fun should_fail_on_malformed_pub_key() {
+        assertFailsWith<IllegalArgumentException> {
+            malformedUnCompressedNums.toXOnlyPubKey()
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined public key conversion handling by introducing a unified utility function for hex-string-to-key conversion, replacing redundant manual parsing logic across multiple components.

* **Tests**
  * Added comprehensive test coverage for the new key conversion utility to validate correct handling of various key formats and error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Resolves #21