### PR TITLE
chore: Bump docker go version 1.26.1 to 1.26.2

### DIFF
--- a/arkade/src/commonMain/kotlin/com/arkade/core/Vtxo.kt
+++ b/arkade/src/commonMain/kotlin/com/arkade/core/Vtxo.kt
@@ -117,6 +117,10 @@ data class Vtxo(
         return now >= exitTime
     }
 
+    data class Data(
+        val outpoint: OutPoint?,
+    )
+
     companion object {
         /**
          * Creates a `VTXO`

--- a/arkade/src/commonMain/kotlin/com/arkade/core/txs/ArkTransaction.kt
+++ b/arkade/src/commonMain/kotlin/com/arkade/core/txs/ArkTransaction.kt
@@ -1,0 +1,19 @@
+package com.arkade.core.txs
+
+sealed class ArkTransaction(
+    override val txId: String,
+    override val tx: String,
+    open val signedCheckpointTxs: List<String>,
+) : Transaction(txId, tx) {
+    class Pending(
+        override val txId: String,
+        override val tx: String,
+        override val signedCheckpointTxs: List<String>,
+    ) : ArkTransaction(txId, tx, signedCheckpointTxs)
+
+    class FullySigned(
+        override val txId: String,
+        override val tx: String,
+        override val signedCheckpointTxs: List<String>,
+    ) : ArkTransaction(txId, tx, signedCheckpointTxs)
+}

--- a/arkade/src/commonMain/kotlin/com/arkade/core/txs/Notification.kt
+++ b/arkade/src/commonMain/kotlin/com/arkade/core/txs/Notification.kt
@@ -1,0 +1,13 @@
+package com.arkade.core.txs
+
+import com.arkade.core.Vtxo
+import fr.acinq.bitcoin.OutPoint
+
+data class Notification(
+    val txId: String,
+    val tx: String,
+    val checkpointTxs: Map<String, Transaction>,
+    val spentVtxos: List<Vtxo.Data>,
+    val spendableVtxos: List<Vtxo.Data>,
+    val sweptVtxos: List<OutPoint>,
+)

--- a/arkade/src/commonMain/kotlin/com/arkade/core/txs/Transaction.kt
+++ b/arkade/src/commonMain/kotlin/com/arkade/core/txs/Transaction.kt
@@ -1,0 +1,6 @@
+package com.arkade.core.txs
+
+open class Transaction(
+    open val txId: String,
+    open val tx: String,
+)

--- a/arkade/src/commonMain/kotlin/com/arkade/core/txs/TxEvent.kt
+++ b/arkade/src/commonMain/kotlin/com/arkade/core/txs/TxEvent.kt
@@ -1,18 +1,16 @@
 package com.arkade.core.txs
 
-import ark.v1.TxNotification
-
 sealed interface TxEvent {
     class CommitmentEvent(
-        val commitmentTx: TxNotification?,
+        val commitmentTx: Notification,
     ) : TxEvent
 
     class ArkEvent(
-        val arkTx: TxNotification?,
+        val arkTx: Notification?,
     ) : TxEvent
 
     class SweepEvent(
-        val sweepTx: TxNotification?,
+        val sweepTx: Notification?,
     ) : TxEvent
 
     object HeartbeatEvent : TxEvent

--- a/arkade/src/commonMain/kotlin/com/arkade/network/ArkadeClient.kt
+++ b/arkade/src/commonMain/kotlin/com/arkade/network/ArkadeClient.kt
@@ -5,6 +5,7 @@ import ark.v1.SubmitTxResponse
 import com.arkade.core.ArkServerInfo
 import com.arkade.core.batches.BatchEvent
 import com.arkade.core.intents.ArkIntent
+import com.arkade.core.txs.ArkTransaction
 import com.arkade.core.txs.TxEvent
 import kotlinx.coroutines.flow.Flow
 
@@ -43,7 +44,7 @@ interface ArkadeClient {
     suspend fun submitTransaction(
         signedArkTx: String,
         checkpointTxs: List<String>,
-    ): SubmitTxResponse
+    ): ArkTransaction
 
     /**
      * Finalize processing a transaction
@@ -94,7 +95,7 @@ interface ArkadeClient {
      * @param intent is the intent
      * @return [List] of [PendingTx]
      */
-    suspend fun getPendingTxs(intent: ArkIntent): List<PendingTx>
+    suspend fun getPendingTxs(intent: ArkIntent): List<ArkTransaction>
 
     /**
      * Streams batch events from the Ark server

--- a/arkade/src/commonMain/kotlin/com/arkade/network/grpc/ArkadeClientImpl.kt
+++ b/arkade/src/commonMain/kotlin/com/arkade/network/grpc/ArkadeClientImpl.kt
@@ -10,25 +10,30 @@ import ark.v1.GetPendingTxRequest
 import ark.v1.GetTransactionsStreamRequest
 import ark.v1.GetTransactionsStreamResponse
 import ark.v1.GrpcArkServiceClient
-import ark.v1.PendingTx
 import ark.v1.RegisterIntentRequest
 import ark.v1.SubmitSignedForfeitTxsRequest
 import ark.v1.SubmitTreeNoncesRequest
 import ark.v1.SubmitTreeSignaturesRequest
-import ark.v1.SubmitTxResponse
+import ark.v1.TxNotification
 import com.arkade.core.ArkServerInfo
 import com.arkade.core.LockedVTXOException
 import com.arkade.core.SpentVTXOException
+import com.arkade.core.Vtxo
 import com.arkade.core.batches.BatchEvent
 import com.arkade.core.bitcoin.Address
 import com.arkade.core.bitcoin.Network
 import com.arkade.core.intents.ArkIntent
+import com.arkade.core.txs.ArkTransaction
+import com.arkade.core.txs.Notification
+import com.arkade.core.txs.Transaction
 import com.arkade.core.txs.TxEvent
 import com.arkade.network.ArkadeClient
 import com.arkade.network.Config
 import com.squareup.wire.GrpcClient
 import com.squareup.wire.bidirectionalStream
+import fr.acinq.bitcoin.OutPoint
 import fr.acinq.bitcoin.PublicKey
+import fr.acinq.bitcoin.TxHash
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.flow.Flow
@@ -113,9 +118,10 @@ class ArkadeClientImpl(
     override suspend fun submitTransaction(
         signedArkTx: String,
         checkpointTxs: List<String>,
-    ): SubmitTxResponse {
+    ): ArkTransaction {
         val txRequest = ark.v1.SubmitTxRequest(signedArkTx, checkpointTxs)
-        return arkadeServiceClient.SubmitTx().execute(txRequest)
+        val txResponse = arkadeServiceClient.SubmitTx().execute(txRequest)
+        return ArkTransaction.FullySigned(txResponse.ark_txid, txResponse.final_ark_tx, txResponse.signed_checkpoint_txs)
     }
 
     override suspend fun finalizeTransaction(
@@ -185,10 +191,16 @@ class ArkadeClientImpl(
         }
     }
 
-    override suspend fun getPendingTxs(intent: ArkIntent): List<PendingTx> {
+    override suspend fun getPendingTxs(intent: ArkIntent): List<ArkTransaction> {
         val request = GetPendingTxRequest(intent.toIntent())
         val response = arkadeServiceClient.GetPendingTx().execute(request)
-        return response.pending_txs
+        return response.pending_txs.map { pendingTx ->
+            ArkTransaction.Pending(
+                pendingTx.ark_txid,
+                pendingTx.final_ark_tx,
+                pendingTx.signed_checkpoint_txs,
+            )
+        }
     }
 }
 
@@ -265,19 +277,48 @@ internal fun GetEventStreamResponse.getBatchEvent(): BatchEvent? =
 internal fun GetTransactionsStreamResponse.getTxEvent(): TxEvent? =
     when {
         commitment_tx != null -> {
-            TxEvent.CommitmentEvent(commitment_tx)
+            TxEvent.CommitmentEvent(commitment_tx.getNotification())
         }
         ark_tx != null -> {
-            TxEvent.ArkEvent(ark_tx)
+            TxEvent.ArkEvent(ark_tx.getNotification())
         }
         sweep_tx != null -> {
-            TxEvent.SweepEvent(sweep_tx)
+            TxEvent.SweepEvent(sweep_tx.getNotification())
         }
         heartbeat != null -> {
             TxEvent.HeartbeatEvent
         }
         else -> null
     }
+
+internal fun TxNotification.getNotification(): Notification {
+    val checkpointTxs =
+        checkpoint_txs.mapValues { checkpointTx ->
+            Transaction(checkpointTx.value.txid, checkpointTx.value.tx)
+        }
+    val spentVtxos =
+        spent_vtxos.map { spentVtxo ->
+            val outpoint = spentVtxo.outpoint?.txid?.let { OutPoint(TxHash(it), spentVtxo.outpoint.vout.toLong()) }
+            Vtxo.Data(outpoint)
+        }
+    val spendableVtxos =
+        spendable_vtxos.map { spendableVtxo ->
+            val outpoint = spendableVtxo.outpoint?.txid?.let { OutPoint(TxHash(it), spendableVtxo.outpoint.vout.toLong()) }
+            Vtxo.Data(outpoint)
+        }
+    val sweptVtxos =
+        swept_vtxos.map { outpoint ->
+            OutPoint(TxHash(outpoint.txid), outpoint.vout.toLong())
+        }
+    return Notification(
+        txid,
+        tx,
+        checkpointTxs,
+        spentVtxos,
+        spendableVtxos,
+        sweptVtxos,
+    )
+}
 
 /**
  * Creates a gRPC client from the provided service url

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,5 +1,5 @@
 # First image used to build the sources
-FROM golang:1.26.1 AS builder
+FROM golang:1.26.2 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/wallet.Dockerfile
+++ b/wallet.Dockerfile
@@ -1,5 +1,5 @@
 # First stage: build the ark-wallet-daemon binary
-FROM golang:1.26.1 AS builder
+FROM golang:1.26.2 AS builder
 
 ARG VERSION
 ARG TARGETOS


### PR DESCRIPTION
https://github.com/arkade-os/arkd/pull/1010

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced transaction submission and tracking with improved state representation
  * Refined transaction event handling and data structures for better transaction management

* **Maintenance**
  * Updated Go toolchain to version 1.26.2 in Docker images for improved stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->