### PR TITLE
chore: Remove build direct dependency on ktlintCheck

### DIFF
--- a/arkade/build.gradle.kts
+++ b/arkade/build.gradle.kts
@@ -1,4 +1,3 @@
-import com.google.devtools.ksp.gradle.KspAATask
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -154,10 +153,3 @@ tasks.register<E2ETestTask>("testE2EDocker") {
 tasks.register<BuildDockerTestTask>("buildDocker")
 
 tasks.register<UnitTestTask>("testUnit")
-
-tasks.getByName("ktlintCheck") {
-    mustRunAfter(tasks.withType<KspAATask>())
-}
-
-// tasks.androidPreBuild.dependsOn("ktlintCheck")
-// tasks.getByName("compileKotlinJvm").dependsOn("ktlintCheck")


### PR DESCRIPTION
`./gradlew build` already invokes `ktlint`, pre-commit hook also invokes the same and ktlint runs as a separate job in CI. With all this setup, there is no need for pre-build `ktlint` checks. We can safely remove it.
And this is a good way that resolves #41  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified build configuration by removing unused task dependencies and imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->