### PR TITLE
fix: HD signer x-only pubkey race conditions (lock with mutex)

### DIFF
--- a/arkade/src/commonMain/kotlin/com/arkade/core/wallet/signer/HDSigner.kt
+++ b/arkade/src/commonMain/kotlin/com/arkade/core/wallet/signer/HDSigner.kt
@@ -82,10 +82,11 @@ class HDSigner private constructor(
      * @param descriptor The output descriptor whose trailing index identifies the child key.
      * @return The corresponding [XonlyPublicKey].
      */
-    override fun xOnlyPublicKey(descriptor: String): XonlyPublicKey {
-        deriveChildPrivateKey(descriptor)
-        return super.xOnlyPublicKey(descriptor)
-    }
+    override suspend fun xOnlyPublicKey(descriptor: String): XonlyPublicKey =
+        mutex.withLock {
+            deriveChildPrivateKey(descriptor)
+            super.xOnlyPublicKey(descriptor)
+        }
 
     /**
      * Builds this wallet's account-level Taproot output descriptor.

--- a/arkade/src/commonMain/kotlin/com/arkade/core/wallet/signer/Signer.kt
+++ b/arkade/src/commonMain/kotlin/com/arkade/core/wallet/signer/Signer.kt
@@ -57,7 +57,7 @@ interface Signer {
      * @param descriptor The output descriptor identifying which key to derive.
      * @return The corresponding [XonlyPublicKey].
      */
-    fun xOnlyPublicKey(descriptor: String): XonlyPublicKey
+    suspend fun xOnlyPublicKey(descriptor: String): XonlyPublicKey
 
     /**
      * Returns this signer's account-level output descriptor.
@@ -150,7 +150,7 @@ SignerImpl : Signer {
      * @param descriptor The output descriptor identifying which key to derive.
      * @return The corresponding [XonlyPublicKey].
      */
-    override fun xOnlyPublicKey(descriptor: String): XonlyPublicKey = privateKey.xOnlyPublicKey()
+    override suspend fun xOnlyPublicKey(descriptor: String): XonlyPublicKey = privateKey.xOnlyPublicKey()
 }
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch event handling and session management for processing batch lifecycles.
  * Added coin modeling with spending metadata and validation.
  * Added wallet-aware contract parsing and persistence.
  * Added filtering for stored VTXOs and contracts.
  * Added support for VTXO expiry heights and transaction outputs.
* **Bug Fixes**
  * Improved concurrent key derivation safety.
  * Corrected expiry conversion to block height.
* **Refactor**
  * Reorganized repository and VTXO APIs for clearer data access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->