### PR TITLE
fix: Fail safely in any caller of updateLastUsedIndex

### DIFF
--- a/arkade/src/commonMain/kotlin/com/arkade/core/wallet/Wallet.kt
+++ b/arkade/src/commonMain/kotlin/com/arkade/core/wallet/Wallet.kt
@@ -64,7 +64,7 @@ interface Wallet : WalletSignerManager {
      *
      * @param index The new last-used address index (must be greater than or equal to 0).
      */
-    suspend fun updateLastUsedIndex(index: Int)
+    suspend fun updateLastUsedIndex(index: Int): Boolean
 
     /**
      * Converts this wallet into a Room persistence entity.

--- a/arkade/src/commonMain/kotlin/com/arkade/core/wallet/WalletImpl.kt
+++ b/arkade/src/commonMain/kotlin/com/arkade/core/wallet/WalletImpl.kt
@@ -15,6 +15,7 @@ import com.arkade.repositories.wallet.WalletRepo
 import fr.acinq.bitcoin.OutPoint
 import fr.acinq.bitcoin.Transaction
 import fr.acinq.bitcoin.psbt.Psbt
+import kotlinx.coroutines.CancellationException
 
 /**
  * Default [Wallet] implementation backed by a [WalletRepo] for persistence.
@@ -90,6 +91,7 @@ class WalletImpl(
             runCatching {
                 update()
             }.onFailure {
+                if (it is CancellationException) throw it
                 if (lastUsedIndex == index) lastUsedIndex = oldLastUsedIndex
             }
         return result.isSuccess

--- a/arkade/src/commonMain/kotlin/com/arkade/core/wallet/WalletImpl.kt
+++ b/arkade/src/commonMain/kotlin/com/arkade/core/wallet/WalletImpl.kt
@@ -82,13 +82,17 @@ class WalletImpl(
      * @param index The new last-used index; must be greater than or equal to the current value.
      * @throws IllegalArgumentException if `index` is less than the current `lastUsedIndex`.
      */
-    override suspend fun updateLastUsedIndex(index: Int) {
+    override suspend fun updateLastUsedIndex(index: Int): Boolean {
         require(index >= lastUsedIndex) { "Invalid last used index" }
         val oldLastUsedIndex = lastUsedIndex
         lastUsedIndex = index
-        runCatching { update() }.onFailure {
-            if (lastUsedIndex == index) lastUsedIndex = oldLastUsedIndex
-        }
+        val result =
+            runCatching {
+                update()
+            }.onFailure {
+                if (lastUsedIndex == index) lastUsedIndex = oldLastUsedIndex
+            }
+        return result.isSuccess
     }
 
     override suspend fun saveVtxo(vtxo: Vtxo.Data) = repo.saveVtxo(vtxo)

--- a/arkade/src/commonMain/kotlin/com/arkade/core/wallet/addresses/HDAddressProvider.kt
+++ b/arkade/src/commonMain/kotlin/com/arkade/core/wallet/addresses/HDAddressProvider.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.sync.withLock
 class HDAddressProvider(
     private val accountDescriptor: String,
     private val getLastUsedIndex: () -> Int,
-    private val updateLastUsedIndex: suspend (Int) -> Unit = {},
+    private val updateLastUsedIndex: suspend (Int) -> Boolean,
 ) : AddressProvider {
     private val mutex = Mutex()
 
@@ -32,8 +32,11 @@ class HDAddressProvider(
     override suspend fun getNextSigningDescriptor(): String =
         mutex.withLock {
             val newIndex = getLastUsedIndex() + 1
-            updateLastUsedIndex(newIndex)
-            getNextDescriptorFromIndex(accountDescriptor, newIndex)
+            if (updateLastUsedIndex(newIndex)) {
+                getNextDescriptorFromIndex(accountDescriptor, newIndex)
+            } else {
+                throw IllegalStateException("Cannot create next descriptor, failed to update last used index")
+            }
         }
 
     /**

--- a/arkade/src/commonMain/kotlin/com/arkade/core/wallet/signer/Signer.kt
+++ b/arkade/src/commonMain/kotlin/com/arkade/core/wallet/signer/Signer.kt
@@ -201,7 +201,6 @@ SignerImpl : Signer {
      * @throws IllegalStateException if signing any of the targeted inputs fails.
      */
 
-  
     private fun signAll(
         psbt: Psbt,
         indices: Iterable<Int> = psbt.inputs.indices,

--- a/arkade/src/commonTest/kotlin/com/arkade/core/wallet/HDSignerTest.kt
+++ b/arkade/src/commonTest/kotlin/com/arkade/core/wallet/HDSignerTest.kt
@@ -5,6 +5,7 @@ import com.arkade.core.wallet.addresses.HDAddressProvider
 import com.arkade.core.wallet.signer.HDSigner
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class HDSignerTest : SignerTest() {
@@ -47,6 +48,21 @@ class HDSignerTest : SignerTest() {
                 val descriptor = addressProvider.getNextSigningDescriptor()
                 assertTrue(descriptors.add(descriptor))
                 testSigningTransaction(descriptor, signer)
+            }
+        }
+    }
+
+    @Test
+    fun should_fail_generating_new_descriptor_when_update_last_used_index_fails() {
+        runTest {
+            val failingProvider =
+                HDAddressProvider(
+                    signer.accountDescriptor(),
+                    getLastUsedIndex = { 0 },
+                    updateLastUsedIndex = { false },
+                )
+            assertFailsWith<IllegalStateException> {
+                failingProvider.getNextSigningDescriptor()
             }
         }
     }

--- a/arkade/src/commonTest/kotlin/com/arkade/core/wallet/HDSignerTest.kt
+++ b/arkade/src/commonTest/kotlin/com/arkade/core/wallet/HDSignerTest.kt
@@ -19,6 +19,7 @@ class HDSignerTest : SignerTest() {
             },
             updateLastUsedIndex = {
                 lastUsedIndex = it
+                true
             },
         )
 


### PR DESCRIPTION
Resolves #85 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wallet address index updates now report whether they succeeded.
  * Address derivation proceeds only after a successful index update, with an error reported when updating fails.

* **Tests**
  * Updated wallet signing test coverage to reflect the success result from index updates.

* **Style**
  * Minor documentation formatting cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->