### PR TITLE
feat: Handle onTreeNoncesEvent in batch session

### DIFF
--- a/arkade/src/commonMain/kotlin/com/arkade/core/batches/BatchEventHandler.kt
+++ b/arkade/src/commonMain/kotlin/com/arkade/core/batches/BatchEventHandler.kt
@@ -31,7 +31,7 @@ interface BatchEventHandler {
     /**
      * Called when signing of the VTXO tree has started.
      */
-    suspend fun onTreeSigningStarted(event: BatchEvent.TreeSigningStartedEvent)
+    suspend fun onTreeSigningStarted(event: BatchEvent.TreeSigningStartedEvent): TreeSignerSession
 
     /**
      * Called when the VTXO tree signing nonces have been aggregated by the server.
@@ -51,5 +51,5 @@ interface BatchEventHandler {
     /**
      * Called when VTXO tree signing nonces are received from the server.
      */
-    suspend fun onTreeNonces()
+    suspend fun onTreeNonces(event: BatchEvent.TreeNoncesEvent)
 }

--- a/arkade/src/commonMain/kotlin/com/arkade/core/batches/BatchSession.kt
+++ b/arkade/src/commonMain/kotlin/com/arkade/core/batches/BatchSession.kt
@@ -15,6 +15,7 @@ import com.arkade.core.wallet.Wallet
 import com.arkade.network.ArkadeClient
 import com.arkade.utils.Log
 import com.arkade.utils.info
+import fr.acinq.bitcoin.ByteVector
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.Transaction
 import fr.acinq.bitcoin.TxId
@@ -309,7 +310,7 @@ class BatchSession(
         if (signerSession != null) {
             val treeNonces =
                 event.treeNonces.map { nonce ->
-                    IndividualNonce(nonce.value)
+                    IndividualNonce(ByteVector.fromHex(nonce.value))
                 }
             val txId = TxId(event.txId)
             signerSession?.aggregateNonces(treeNonces, txId)

--- a/arkade/src/commonMain/kotlin/com/arkade/core/batches/BatchSession.kt
+++ b/arkade/src/commonMain/kotlin/com/arkade/core/batches/BatchSession.kt
@@ -19,6 +19,7 @@ import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.Transaction
 import fr.acinq.bitcoin.TxId
 import fr.acinq.bitcoin.TxOut
+import fr.acinq.bitcoin.crypto.musig2.IndividualNonce
 import fr.acinq.bitcoin.psbt.Psbt
 import fr.acinq.bitcoin.utils.getOrDefault
 import fr.acinq.bitcoin.utils.getOrElse
@@ -55,6 +56,8 @@ class BatchSession(
     private val connectors: MutableList<TxTreeNode> = mutableListOf()
 
     private lateinit var serverInfo: ArkServerInfo
+
+    private var signerSession: TreeSignerSession? = null
 
     var isComplete = false
         private set
@@ -98,7 +101,7 @@ class BatchSession(
                 is BatchEvent.BatchFailedEvent -> onBatchFailed(event)
 
                 is BatchEvent.TreeSigningStartedEvent -> {
-                    onTreeSigningStarted(event)
+                    signerSession = onTreeSigningStarted(event)
                 }
 
                 is BatchEvent.TreeNoncesAggregatedEvent -> {
@@ -114,7 +117,7 @@ class BatchSession(
                 }
 
                 is BatchEvent.TreeNoncesEvent -> {
-                    onTreeNonces()
+                    onTreeNonces(event)
                 }
 
                 is BatchEvent.HeartbeatEvent -> {}
@@ -236,7 +239,7 @@ class BatchSession(
         }
     }
 
-    override suspend fun onTreeSigningStarted(event: BatchEvent.TreeSigningStartedEvent) {
+    override suspend fun onTreeSigningStarted(event: BatchEvent.TreeSigningStartedEvent): TreeSignerSession {
         val vtxoGraph = TxTree.create(vtxos)
         val commitmentTx = Psbt.read(event.unsignedCommitmentTx.encodeToByteArray()).getOrDefault(null)
         if (commitmentTx != null) {
@@ -278,6 +281,7 @@ class BatchSession(
             signerPubKey.value.toHex(),
             nonces,
         )
+        return signerSession
     }
 
     override suspend fun onTreeNoncesAggregated() {
@@ -301,8 +305,15 @@ class BatchSession(
         TODO("Not yet implemented")
     }
 
-    override suspend fun onTreeNonces() {
-        TODO("Not yet implemented")
+    override suspend fun onTreeNonces(event: BatchEvent.TreeNoncesEvent) {
+        if (signerSession != null) {
+            val treeNonces =
+                event.treeNonces.map { nonce ->
+                    IndividualNonce(nonce.value)
+                }
+            val txId = TxId(event.txId)
+            signerSession?.aggregateNonces(treeNonces, txId)
+        }
     }
 
     private fun parseIntentOutputs(): List<TxOut> {

--- a/arkade/src/commonMain/kotlin/com/arkade/core/batches/TreeSignerSession.kt
+++ b/arkade/src/commonMain/kotlin/com/arkade/core/batches/TreeSignerSession.kt
@@ -5,7 +5,9 @@ import com.arkade.core.wallet.Wallet
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.Script
 import fr.acinq.bitcoin.SigHash
+import fr.acinq.bitcoin.TxId
 import fr.acinq.bitcoin.TxOut
+import fr.acinq.bitcoin.crypto.musig2.AggregatedNonce
 import fr.acinq.bitcoin.crypto.musig2.IndividualNonce
 import fr.acinq.bitcoin.crypto.musig2.Musig2
 import fr.acinq.bitcoin.crypto.musig2.SecretNonce
@@ -19,6 +21,7 @@ class TreeSignerSession(
     private val rootSharedOutputAmount: Long,
 ) {
     private var nonces: Map<ByteVector32, Pair<SecretNonce, IndividualNonce>>? = null
+    private var aggregatedNonce: AggregatedNonce? = null
 
     suspend fun generateNonces(): Map<ByteVector32, Pair<SecretNonce, IndividualNonce>> {
         if (nonces != null) {
@@ -110,5 +113,20 @@ class TreeSignerSession(
         val parentOutput = parent.root.global.tx.txOut[parentInput.outPoint.index.toInt()]
 
         return TxOut(parentOutput.amount, scriptPubKey)
+    }
+
+    fun aggregateNonces(
+        treeNonces: List<IndividualNonce>,
+        txId: TxId,
+    ) {
+        val myNonce = nonces?.get(txId.value)
+        if (nonces == null || myNonce == null) {
+            throw UnsupportedOperationException("Missing private nonce")
+        }
+        if (!treeNonces.any { nonce -> nonce.data == myNonce.second.data }) {
+            throw UnsupportedOperationException("Missing my nonce")
+        }
+
+        aggregatedNonce = IndividualNonce.aggregate(treeNonces).right
     }
 }

--- a/arkade/src/commonMain/kotlin/com/arkade/core/batches/TreeSignerSession.kt
+++ b/arkade/src/commonMain/kotlin/com/arkade/core/batches/TreeSignerSession.kt
@@ -21,7 +21,7 @@ class TreeSignerSession(
     private val rootSharedOutputAmount: Long,
 ) {
     private var nonces: Map<ByteVector32, Pair<SecretNonce, IndividualNonce>>? = null
-    private var aggregatedNonce: AggregatedNonce? = null
+    private val aggregatedNonces: MutableMap<ByteVector32, AggregatedNonce> = mutableMapOf()
 
     suspend fun generateNonces(): Map<ByteVector32, Pair<SecretNonce, IndividualNonce>> {
         if (nonces != null) {
@@ -127,6 +127,9 @@ class TreeSignerSession(
             throw UnsupportedOperationException("Missing my nonce")
         }
 
-        aggregatedNonce = IndividualNonce.aggregate(treeNonces).right
+        val aggregatedNonce =
+            IndividualNonce.aggregate(treeNonces).right
+                ?: throw UnsupportedOperationException("Failed to aggregate nonces")
+        aggregatedNonces[txId.value] = aggregatedNonce
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tracking active tree-signing sessions during batch processing.
  * Added aggregation of transaction-specific tree nonces during signing.
  * Added validation to ensure the expected private nonce is included before aggregation.
* **Bug Fixes**
  * Tree nonce events are now processed correctly instead of being ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->