### PR TITLE
feat: Handle onTreeNoncesAggregatedEvent in batch session

### DIFF
--- a/arkade/src/commonMain/kotlin/com/arkade/core/batches/BatchEventHandler.kt
+++ b/arkade/src/commonMain/kotlin/com/arkade/core/batches/BatchEventHandler.kt
@@ -36,7 +36,7 @@ interface BatchEventHandler {
     /**
      * Called when the VTXO tree signing nonces have been aggregated by the server.
      */
-    suspend fun onTreeNoncesAggregated()
+    suspend fun onTreeNoncesAggregated(event: BatchEvent.TreeNoncesAggregatedEvent)
 
     /**
      * Called when a VTXO tree transaction is received from the server.

--- a/arkade/src/commonMain/kotlin/com/arkade/core/batches/BatchSession.kt
+++ b/arkade/src/commonMain/kotlin/com/arkade/core/batches/BatchSession.kt
@@ -1,5 +1,6 @@
 package com.arkade.core.batches
 
+import ark.v1.TreeNoncesAggregatedEvent
 import com.arkade.core.ArkServerInfo
 import com.arkade.core.ArkTransactionBuilder
 import com.arkade.core.assets.Extension
@@ -17,6 +18,7 @@ import com.arkade.utils.Log
 import com.arkade.utils.info
 import fr.acinq.bitcoin.ByteVector
 import fr.acinq.bitcoin.ByteVector32
+import fr.acinq.bitcoin.ScriptTree
 import fr.acinq.bitcoin.Transaction
 import fr.acinq.bitcoin.TxId
 import fr.acinq.bitcoin.TxOut
@@ -53,6 +55,7 @@ class BatchSession(
 
     private val signerDescriptor = intent.signerDescriptor
     private lateinit var sweepTapScript: ByteArray
+    private lateinit var sweepTapTree: ScriptTree
     private val vtxos: MutableList<TxTreeNode> = mutableListOf()
     private val connectors: MutableList<TxTreeNode> = mutableListOf()
 
@@ -106,7 +109,7 @@ class BatchSession(
                 }
 
                 is BatchEvent.TreeNoncesAggregatedEvent -> {
-                    onTreeNoncesAggregated()
+                    onTreeNoncesAggregated(event)
                 }
 
                 is BatchEvent.TreeTxEvent -> {
@@ -258,7 +261,7 @@ class BatchSession(
                 wallet,
                 vtxoGraph,
                 signerDescriptor!!,
-                sweepTapScript,
+                sweepTapTree,
                 sharedOutput.amount.sat,
             )
 
@@ -285,8 +288,31 @@ class BatchSession(
         return signerSession
     }
 
-    override suspend fun onTreeNoncesAggregated() {
-        TODO("Not yet implemented")
+    override suspend fun onTreeNoncesAggregated(event: BatchEvent.TreeNoncesAggregatedEvent) {
+        if (signerSession != null && signerDescriptor != null) {
+            val treeNonces =
+                event.treeNonces.entries.associate { entry ->
+                    val pubNonce = IndividualNonce(ByteVector.fromHex(entry.value))
+                    val txId = ByteVector32.fromValidHex(entry.key)
+                    txId to pubNonce
+                }
+            signerSession?.verifyAggregatedNonces(treeNonces)
+
+            val signatures =
+                signerSession?.sign()?.entries?.associate { entry ->
+                    entry.key.toHex() to entry.value.toHex()
+                }!!
+
+            val signerPubKey =
+                wallet.signer
+                    .xOnlyPublicKey(signerDescriptor)
+                    .value
+                    .toHex()
+
+            Log.info(LOG_TAG, "SubmitTreeSignatures: using signerPubKey=$signerPubKey")
+
+            client.submitTreeSignatures(batchId, signerPubKey, signatures)
+        }
     }
 
     override suspend fun onTreeTx(event: BatchEvent.TreeTxEvent) {

--- a/arkade/src/commonMain/kotlin/com/arkade/core/batches/BatchSession.kt
+++ b/arkade/src/commonMain/kotlin/com/arkade/core/batches/BatchSession.kt
@@ -6,6 +6,7 @@ import com.arkade.core.ArkTransactionBuilder
 import com.arkade.core.assets.Extension
 import com.arkade.core.assets.Extension.Companion.isExtension
 import com.arkade.core.assets.Packet
+import com.arkade.core.buildScriptTree
 import com.arkade.core.coins.ArkCoin
 import com.arkade.core.csvSigScript
 import com.arkade.core.intents.ArkIntent
@@ -54,7 +55,6 @@ class BatchSession(
     private val intentParameters = RegisterIntentMessage.fromString(intent.registerProofMessage)
 
     private val signerDescriptor = intent.signerDescriptor
-    private lateinit var sweepTapScript: ByteArray
     private lateinit var sweepTapTree: ScriptTree
     private val vtxos: MutableList<TxTreeNode> = mutableListOf()
     private val connectors: MutableList<TxTreeNode> = mutableListOf()
@@ -67,14 +67,15 @@ class BatchSession(
         private set
 
     /**
-     * Fetches [serverInfo] from [client] and derives [sweepTapScript] from the batch's expiry
+     * Fetches [serverInfo] from [client] and derives [sweepTapTree] from the batch's expiry
      * and the server's forfeit public key.
      *
      * Must be called before [processEvent] handles a [BatchEvent.BatchFinalizationEvent].
      */
     suspend fun init() {
         serverInfo = client.getInfo()
-        sweepTapScript = csvSigScript(batchStartedEvent.batchExpiry.inWholeSeconds, serverInfo.forfeitPubKey)
+        val unilateralExitScript = csvSigScript(batchStartedEvent.batchExpiry.inWholeSeconds, serverInfo.forfeitPubKey)
+        sweepTapTree = buildScriptTree(listOf(unilateralExitScript))
     }
 
     /**
@@ -247,7 +248,7 @@ class BatchSession(
         val vtxoGraph = TxTree.create(vtxos)
         val commitmentTx = Psbt.read(event.unsignedCommitmentTx.encodeToByteArray()).getOrDefault(null)
         if (commitmentTx != null) {
-            TreeValidator.validateVtxoTxGraph(vtxoGraph, commitmentTx, ByteVector32(sweepTapScript))
+            TreeValidator.validateVtxoTxGraph(vtxoGraph, commitmentTx, sweepTapTree.hash())
 
             validateIntentOutputs(vtxoGraph, commitmentTx)
         }

--- a/arkade/src/commonMain/kotlin/com/arkade/core/batches/TreeSignerSession.kt
+++ b/arkade/src/commonMain/kotlin/com/arkade/core/batches/TreeSignerSession.kt
@@ -3,7 +3,9 @@ package com.arkade.core.batches
 import com.arkade.core.getArkFieldsCosigners
 import com.arkade.core.wallet.Wallet
 import fr.acinq.bitcoin.ByteVector32
+import fr.acinq.bitcoin.PublicKey
 import fr.acinq.bitcoin.Script
+import fr.acinq.bitcoin.ScriptTree
 import fr.acinq.bitcoin.SigHash
 import fr.acinq.bitcoin.TxId
 import fr.acinq.bitcoin.TxOut
@@ -17,9 +19,10 @@ class TreeSignerSession(
     private val wallet: Wallet,
     private val graph: TxTree,
     private val descriptor: String,
-    private val tapScriptMerkleRoot: ByteArray?,
+    private val tapScriptTree: ScriptTree?,
     private val rootSharedOutputAmount: Long,
 ) {
+    private val tapScriptTreeRoot = tapScriptTree?.hash()
     private var nonces: Map<ByteVector32, Pair<SecretNonce, IndividualNonce>>? = null
     private val aggregatedNonces: MutableMap<ByteVector32, AggregatedNonce> = mutableMapOf()
 
@@ -48,13 +51,13 @@ class TreeSignerSession(
 
             val prevOut = getPrevOutput(node, graph)
 
-            if (tapScriptMerkleRoot != null) {
+            if (tapScriptTreeRoot != null) {
                 val sigHash =
                     tx.hashForSigningTaprootScriptPath(
                         0,
                         listOf(prevOut),
                         SigHash.SIGHASH_DEFAULT,
-                        ByteVector32(tapScriptMerkleRoot),
+                        tapScriptTreeRoot,
                     )
 
                 val nonce =
@@ -89,15 +92,13 @@ class TreeSignerSession(
 
         val aggregatedKey = Musig2.aggregateKeys(cosignerKeys)
 
-        if (tapScriptMerkleRoot == null) {
+        if (tapScriptTreeRoot == null) {
             throw UnsupportedOperationException("Script root not set")
         }
 
-        val merkleRoot = ByteVector32(tapScriptMerkleRoot)
-
         val txId = graph.root.global.tx.txid
 
-        val scriptPubKey = Script.pay2tr(aggregatedKey, merkleRoot)
+        val scriptPubKey = Script.pay2tr(aggregatedKey, tapScriptTreeRoot)
 
         if (txId == rootGraph.root.global.tx.txid) {
             return TxOut(rootSharedOutputAmount.sat(), scriptPubKey)
@@ -132,4 +133,74 @@ class TreeSignerSession(
                 ?: throw UnsupportedOperationException("Failed to aggregate nonces")
         aggregatedNonces[txId.value] = aggregatedNonce
     }
+
+    fun verifyAggregatedNonces(expected: Map<ByteVector32, IndividualNonce>) {
+        if (nonces == null) {
+            throw UnsupportedOperationException("Nonces not generated")
+        }
+        val isMatching =
+            expected.all { entry ->
+                val nonce =
+                    aggregatedNonces[entry.key]
+                        ?: throw UnsupportedOperationException("Aggregated nonce missing")
+                nonce.data == entry.value.data
+            }
+        if (!isMatching) {
+            throw UnsupportedOperationException("Aggregaed nonces do not match")
+        }
+    }
+
+    suspend fun sign(): Map<ByteVector32, ByteVector32> {
+        if (nonces == null) {
+            throw UnsupportedOperationException("Nonces not generated")
+        }
+
+        val signatures: MutableMap<ByteVector32, ByteVector32> = mutableMapOf()
+        graph.forEach { nodeTxTree ->
+            val txId = nodeTxTree.root.global.tx.txid.value
+            if (nonces?.containsKey(txId) == true) {
+                return@forEach
+            }
+            val signature = signPartial(nodeTxTree)
+            signatures[txId] = signature
+        }
+        return signatures
+    }
+
+    private suspend fun signPartial(nodeTxTree: TxTree): ByteVector32 {
+        if (nonces == null) {
+            throw UnsupportedOperationException("Session not properly initialized")
+        }
+
+        val tx = nodeTxTree.root.global.tx
+        val txId = tx.txid.value
+
+        val privNonce = nonces!![txId]?.first ?: throw UnsupportedOperationException("Missing private nonce")
+
+        val prevOut = getPrevOutput(nodeTxTree, graph)
+
+        val cosignerPubKeys = nodeTxTree.getCosignerPubKeys()
+
+        val pubNonces = nonces?.map { (_, nonce) -> nonce.second }!!
+
+        val partialSig =
+            wallet.signer.signMusig(
+                descriptor,
+                tx,
+                listOf(prevOut),
+                0,
+                privNonce,
+                cosignerPubKeys,
+                pubNonces,
+                tapScriptTree,
+            )
+
+        return partialSig
+    }
+
+    private fun TxTree.getCosignerPubKeys(): List<PublicKey> =
+        root.inputs[0]
+            .getArkFieldsCosigners()
+            .sortedBy { it.index }
+            .map { it.pubKey }
 }

--- a/arkade/src/commonMain/kotlin/com/arkade/core/batches/TreeSignerSession.kt
+++ b/arkade/src/commonMain/kotlin/com/arkade/core/batches/TreeSignerSession.kt
@@ -23,11 +23,12 @@ class TreeSignerSession(
     private val rootSharedOutputAmount: Long,
 ) {
     private val tapScriptTreeRoot = tapScriptTree.hash()
-    private var nonces: Map<ByteVector32, Pair<SecretNonce, IndividualNonce>>? = null
+    private var myNonces: Map<ByteVector32, Pair<SecretNonce, IndividualNonce>>? = null
+    private val treeNonces: MutableMap<ByteVector32, List<IndividualNonce>> = mutableMapOf()
     private val aggregatedNonces: MutableMap<ByteVector32, AggregatedNonce> = mutableMapOf()
 
     suspend fun generateNonces(): Map<ByteVector32, Pair<SecretNonce, IndividualNonce>> {
-        if (nonces != null) {
+        if (myNonces != null) {
             throw UnsupportedOperationException("Nonces already generated")
         }
         val signer = wallet.signer
@@ -72,10 +73,10 @@ class TreeSignerSession(
     }
 
     suspend fun getNonces(): Map<ByteVector32, IndividualNonce> {
-        if (nonces == null) {
-            nonces = generateNonces()
+        if (myNonces == null) {
+            myNonces = generateNonces()
         }
-        return nonces?.mapValues { it.value.second }!!
+        return myNonces?.mapValues { it.value.second }!!
     }
 
     private fun getPrevOutput(
@@ -110,8 +111,9 @@ class TreeSignerSession(
         treeNonces: List<IndividualNonce>,
         txId: TxId,
     ) {
-        val myNonce = nonces?.get(txId.value)
-        if (nonces == null || myNonce == null) {
+        val txId = txId.value
+        val myNonce = myNonces?.get(txId)
+        if (myNonces == null || myNonce == null) {
             throw UnsupportedOperationException("Missing private nonce")
         }
         if (!treeNonces.any { nonce -> nonce.data == myNonce.second.data }) {
@@ -120,12 +122,13 @@ class TreeSignerSession(
 
         val aggregatedNonce =
             IndividualNonce.aggregate(treeNonces).right
-                ?: throw UnsupportedOperationException("Failed to aggregate nonces")
-        aggregatedNonces[txId.value] = aggregatedNonce
+                ?: throw UnsupportedOperationException("Failed to aggregate myNonces")
+        this.treeNonces[txId] = treeNonces
+        aggregatedNonces[txId] = aggregatedNonce
     }
 
     fun verifyAggregatedNonces(expected: Map<ByteVector32, IndividualNonce>) {
-        if (nonces == null) {
+        if (myNonces == null) {
             throw UnsupportedOperationException("Nonces not generated")
         }
         val isMatching =
@@ -136,19 +139,19 @@ class TreeSignerSession(
                 nonce.data == entry.value.data
             }
         if (!isMatching) {
-            throw UnsupportedOperationException("Aggregated nonces do not match")
+            throw UnsupportedOperationException("Aggregated myNonces do not match")
         }
     }
 
     suspend fun sign(): Map<ByteVector32, ByteVector32> {
-        if (nonces == null) {
+        if (myNonces == null) {
             throw UnsupportedOperationException("Nonces not generated")
         }
 
         val signatures: MutableMap<ByteVector32, ByteVector32> = mutableMapOf()
         graph.forEach { nodeTxTree ->
             val txId = nodeTxTree.root.global.tx.txid.value
-            if (nonces?.containsKey(txId) == false) {
+            if (myNonces?.containsKey(txId) == false) {
                 return@forEach
             }
             val signature = signPartial(nodeTxTree)
@@ -158,20 +161,20 @@ class TreeSignerSession(
     }
 
     private suspend fun signPartial(nodeTxTree: TxTree): ByteVector32 {
-        if (nonces == null) {
+        if (myNonces == null) {
             throw UnsupportedOperationException("Session not properly initialized")
         }
 
         val tx = nodeTxTree.root.global.tx
         val txId = tx.txid.value
 
-        val privNonce = nonces!![txId]?.first ?: throw UnsupportedOperationException("Missing private nonce")
+        val privNonce = myNonces!![txId]?.first ?: throw UnsupportedOperationException("Missing private nonce")
 
         val prevOut = getPrevOutput(nodeTxTree, graph)
 
         val cosignerPubKeys = nodeTxTree.getCosignerPubKeys()
 
-        val pubNonces = nonces?.map { (_, nonce) -> nonce.second }!!
+        val pubNonces = treeNonces[txId] ?: throw UnsupportedOperationException("Missing tree nonces")
 
         val partialSig =
             wallet.signer.signMusig(

--- a/arkade/src/commonMain/kotlin/com/arkade/core/batches/TreeSignerSession.kt
+++ b/arkade/src/commonMain/kotlin/com/arkade/core/batches/TreeSignerSession.kt
@@ -19,10 +19,10 @@ class TreeSignerSession(
     private val wallet: Wallet,
     private val graph: TxTree,
     private val descriptor: String,
-    private val tapScriptTree: ScriptTree?,
+    private val tapScriptTree: ScriptTree,
     private val rootSharedOutputAmount: Long,
 ) {
-    private val tapScriptTreeRoot = tapScriptTree?.hash()
+    private val tapScriptTreeRoot = tapScriptTree.hash()
     private var nonces: Map<ByteVector32, Pair<SecretNonce, IndividualNonce>>? = null
     private val aggregatedNonces: MutableMap<ByteVector32, AggregatedNonce> = mutableMapOf()
 
@@ -51,24 +51,22 @@ class TreeSignerSession(
 
             val prevOut = getPrevOutput(node, graph)
 
-            if (tapScriptTreeRoot != null) {
-                val sigHash =
-                    tx.hashForSigningTaprootScriptPath(
-                        0,
-                        listOf(prevOut),
-                        SigHash.SIGHASH_DEFAULT,
-                        tapScriptTreeRoot,
-                    )
+            val sigHash =
+                tx.hashForSigningTaprootScriptPath(
+                    0,
+                    listOf(prevOut),
+                    SigHash.SIGHASH_DEFAULT,
+                    tapScriptTreeRoot,
+                )
 
-                val nonce =
-                    signer.generateNonce(
-                        txId.value,
-                        descriptor,
-                        cosignersKeys,
-                        sigHash,
-                    )
-                treeNonces[txId.value] = nonce
-            }
+            val nonce =
+                signer.generateNonce(
+                    txId.value,
+                    descriptor,
+                    cosignersKeys,
+                    sigHash,
+                )
+            treeNonces[txId.value] = nonce
         }
         return treeNonces
     }
@@ -84,17 +82,9 @@ class TreeSignerSession(
         graph: TxTree,
         rootGraph: TxTree,
     ): TxOut {
-        val cosignerKeys =
-            graph.root.inputs[0]
-                .getArkFieldsCosigners()
-                .sortedBy { it.index }
-                .map { it.pubKey }
+        val cosignerKeys = graph.getCosignerPubKeys()
 
         val aggregatedKey = Musig2.aggregateKeys(cosignerKeys)
-
-        if (tapScriptTreeRoot == null) {
-            throw UnsupportedOperationException("Script root not set")
-        }
 
         val txId = graph.root.global.tx.txid
 
@@ -146,7 +136,7 @@ class TreeSignerSession(
                 nonce.data == entry.value.data
             }
         if (!isMatching) {
-            throw UnsupportedOperationException("Aggregaed nonces do not match")
+            throw UnsupportedOperationException("Aggregated nonces do not match")
         }
     }
 
@@ -158,7 +148,7 @@ class TreeSignerSession(
         val signatures: MutableMap<ByteVector32, ByteVector32> = mutableMapOf()
         graph.forEach { nodeTxTree ->
             val txId = nodeTxTree.root.global.tx.txid.value
-            if (nonces?.containsKey(txId) == true) {
+            if (nonces?.containsKey(txId) == false) {
                 return@forEach
             }
             val signature = signPartial(nodeTxTree)

--- a/arkade/src/commonMain/kotlin/com/arkade/core/batches/TreeSignerSession.kt
+++ b/arkade/src/commonMain/kotlin/com/arkade/core/batches/TreeSignerSession.kt
@@ -34,7 +34,7 @@ class TreeSignerSession(
         val signer = wallet.signer
         val myPubKey = signer.xOnlyPublicKey(descriptor)
 
-        val treeNonces: MutableMap<ByteVector32, Pair<SecretNonce, IndividualNonce>> = mutableMapOf()
+        val myNonces: MutableMap<ByteVector32, Pair<SecretNonce, IndividualNonce>> = mutableMapOf()
 
         graph.forEach { node ->
             val tx = node.root.global.tx
@@ -67,9 +67,9 @@ class TreeSignerSession(
                     cosignersKeys,
                     sigHash,
                 )
-            treeNonces[txId.value] = nonce
+            myNonces[txId.value] = nonce
         }
-        return treeNonces
+        return myNonces
     }
 
     suspend fun getNonces(): Map<ByteVector32, IndividualNonce> {

--- a/arkade/src/commonMain/kotlin/com/arkade/core/batches/TreeSignerSession.kt
+++ b/arkade/src/commonMain/kotlin/com/arkade/core/batches/TreeSignerSession.kt
@@ -40,11 +40,7 @@ class TreeSignerSession(
             val tx = node.root.global.tx
             val txId = tx.txid
 
-            val cosignersKeys =
-                node.root.inputs[0]
-                    .getArkFieldsCosigners()
-                    .sortedBy { it.index }
-                    .map { it.pubKey }
+            val cosignersKeys = node.getCosignerPubKeys()
 
             if (cosignersKeys.all { it.xOnly() != myPubKey }) {
                 return@forEach

--- a/arkade/src/commonMain/kotlin/com/arkade/core/batches/TreeSignerSession.kt
+++ b/arkade/src/commonMain/kotlin/com/arkade/core/batches/TreeSignerSession.kt
@@ -122,7 +122,7 @@ class TreeSignerSession(
 
         val aggregatedNonce =
             IndividualNonce.aggregate(treeNonces).right
-                ?: throw UnsupportedOperationException("Failed to aggregate myNonces")
+                ?: throw UnsupportedOperationException("Failed to aggregate nonces")
         this.treeNonces[txId] = treeNonces
         aggregatedNonces[txId] = aggregatedNonce
     }

--- a/arkade/src/commonMain/kotlin/com/arkade/core/wallet/signer/Signer.kt
+++ b/arkade/src/commonMain/kotlin/com/arkade/core/wallet/signer/Signer.kt
@@ -5,7 +5,9 @@ import fr.acinq.bitcoin.Crypto
 import fr.acinq.bitcoin.OutPoint
 import fr.acinq.bitcoin.PrivateKey
 import fr.acinq.bitcoin.PublicKey
+import fr.acinq.bitcoin.ScriptTree
 import fr.acinq.bitcoin.Transaction
+import fr.acinq.bitcoin.TxOut
 import fr.acinq.bitcoin.XonlyPublicKey
 import fr.acinq.bitcoin.crypto.musig2.IndividualNonce
 import fr.acinq.bitcoin.crypto.musig2.Musig2
@@ -93,6 +95,17 @@ interface Signer {
         message: ByteVector32?,
         extraInput: ByteVector32? = null,
     ): Pair<SecretNonce, IndividualNonce>
+
+    suspend fun signMusig(
+        descriptor: String,
+        tx: Transaction,
+        inputs: List<TxOut>,
+        inputIndex: Int,
+        privNonce: SecretNonce,
+        pubKeys: List<PublicKey>,
+        pubNonces: List<IndividualNonce>,
+        scriptTree: ScriptTree?,
+    ): ByteVector32
 }
 
 /**
@@ -116,7 +129,7 @@ SignerImpl : Signer {
      *
      * @param descriptor The output descriptor identifying which key to sign with.
      * @param psbt The PSBT to sign.
-     * @param inputIndexes The indexes of the inputs to sign; if empty, all inputs are signed.
+     * @param inputIndices The indexes of the inputs to sign; if empty, all inputs are signed.
      * @return The fully signed [Transaction].
      * @throws IllegalStateException if signing any of the targeted inputs fails.
      */
@@ -214,6 +227,28 @@ SignerImpl : Signer {
         val signingKey = Either.Left(privateKey)
         return Musig2.generateNonce(sessionId, signingKey, pubKeys, message, extraInput)
     }
+
+    override suspend fun signMusig(
+        descriptor: String,
+        tx: Transaction,
+        inputs: List<TxOut>,
+        inputIndex: Int,
+        privNonce: SecretNonce,
+        pubKeys: List<PublicKey>,
+        pubNonces: List<IndividualNonce>,
+        scriptTree: ScriptTree?,
+    ): ByteVector32 =
+        Musig2
+            .signTaprootInput(
+                privateKey,
+                tx,
+                inputIndex,
+                inputs,
+                pubKeys,
+                privNonce,
+                pubNonces,
+                scriptTree,
+            ).getOrElse { throw it }
 
     /**
      * Signs each of [indices] on [psbt] with [privateKey], in order, folding the result of each


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for MuSig2 Taproot signing across transaction trees.
  * Batch sessions can now verify aggregated nonces, generate partial signatures, and submit completed tree signatures.
  * Signing now uses full Taproot script trees for improved transaction signing compatibility.
  * Added wallet-level MuSig2 signing support for individual transaction inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->