### PR TITLE
feat: Encapsulate wallet descriptors

### DIFF
--- a/arkade/src/commonMain/kotlin/com/arkade/core/bitcoin/Descriptor.kt
+++ b/arkade/src/commonMain/kotlin/com/arkade/core/bitcoin/Descriptor.kt
@@ -1,0 +1,34 @@
+package com.arkade.core.bitcoin
+
+import com.arkade.core.toXOnlyPubKey
+import fr.acinq.bitcoin.XonlyPublicKey
+
+class Descriptor private constructor() {
+    private var xOnlyPubKey: XonlyPublicKey? = null
+    private constructor (string: String) : this() {
+        this.xOnlyPubKey =
+            if (string.startsWith("tr(") && string.endsWith(")")) {
+                string.removeSurrounding("tr(", ")").toXOnlyPubKey()
+            } else {
+                string.toXOnlyPubKey()
+            }
+    }
+
+    private constructor(pubKey: XonlyPublicKey) : this() {
+        this.xOnlyPubKey = pubKey
+    }
+
+    fun encodeTaproot(): String {
+        val xOnlyPublicKey =
+            requireNotNull(xOnlyPubKey) {
+                "Missing x-only public key"
+            }
+        return "tr(${xOnlyPublicKey.value.toHex()})"
+    }
+
+    companion object {
+        fun from(string: String): Descriptor = Descriptor(string)
+
+        fun from(xPubKey: XonlyPublicKey): Descriptor = Descriptor(xPubKey)
+    }
+}

--- a/arkade/src/commonTest/kotlin/com/arkade/core/bitcoin/DescriptorTest.kt
+++ b/arkade/src/commonTest/kotlin/com/arkade/core/bitcoin/DescriptorTest.kt
@@ -1,0 +1,30 @@
+package com.arkade.core.bitcoin
+
+import com.arkade.core.toXOnlyPubKey
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DescriptorTest {
+    @Test
+    fun decode_taproot_descriptor_from_string() {
+        val compressedPubKey = "03a19310a999207dbd9a03d20f649e37c7a578a07d75e6fa19aa3f33fc6b15622c"
+        val descriptor = "tr(a19310a999207dbd9a03d20f649e37c7a578a07d75e6fa19aa3f33fc6b15622c)"
+
+        val decoded = Descriptor.from(compressedPubKey)
+        val encoded = decoded.encodeTaproot()
+
+        val decodedFromDescriptor = Descriptor.from(descriptor)
+
+        assertEquals(descriptor, decodedFromDescriptor.encodeTaproot())
+        assertEquals(compressedPubKey.toXOnlyPubKey().value.toHex(), encoded.removeSurrounding("tr(", ")"))
+    }
+
+    @Test
+    fun decode_taproot_descriptor_from_x_pubkey() {
+        val xPubKey = "03a19310a999207dbd9a03d20f649e37c7a578a07d75e6fa19aa3f33fc6b15622c".toXOnlyPubKey()
+        val decoded = Descriptor.from(xPubKey)
+        val encoded = decoded.encodeTaproot()
+
+        assertEquals(xPubKey.value.toHex(), encoded.removeSurrounding("tr(", ")"))
+    }
+}


### PR DESCRIPTION
Closes #81 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for creating and parsing Bitcoin Taproot descriptors.
  - Accepts both raw public keys and `tr(...)` descriptor formats.
  - Supports encoding Taproot descriptors from x-only public keys.
- **Tests**
  - Added coverage for parsing and encoding Taproot descriptors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->